### PR TITLE
feat: Blender GPU animation lane (orbit mp4 on the RTX 5070)

### DIFF
--- a/make_video_gpu.sh
+++ b/make_video_gpu.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# make_video_gpu.sh — GPU animation lane: render an orbiting retro-CGI mp4 on the
+# RTX 5070 node (Blender/Cycles + OptiX), encode with ffmpeg.
+#
+#   ./make_video_gpu.sh /path/out.mp4 [secs] [fps] [scene.py]
+#
+# Companion to make_video.sh (POV-Ray/CPU). Uses scenes/blender_anim.py by
+# default. Auth: keyless ssh by default; set RETRO_GPU_PASS to use sshpass.
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+OUT="${1:?usage: make_video_gpu.sh out.mp4 [secs] [fps] [scene.py]}"
+SECS="${2:-3}"; FPS="${3:-24}"
+SCENE="${4:-$HERE/scenes/blender_anim.py}"
+FRAMES=$(( SECS * FPS ))
+
+NODE="${RETRO_GPU_NODE:-192.168.0.106}"
+USER="${RETRO_GPU_USER:-sophia5070node}"
+RBLENDER="${RETRO_REMOTE_BLENDER:-/mnt/data/blender44}"
+RDIR="feverdream"
+
+SSH="ssh"; SCP="scp"
+if [ -n "${RETRO_GPU_PASS:-}" ]; then
+  SSH="sshpass -p $RETRO_GPU_PASS ssh -o PreferredAuthentications=password -o PubkeyAuthentication=no"
+  SCP="sshpass -p $RETRO_GPU_PASS scp -o PreferredAuthentications=password -o PubkeyAuthentication=no"
+fi
+SSHOPTS="-o StrictHostKeyChecking=no -o ConnectTimeout=10"
+
+echo ">> [gpu] staging on $USER@$NODE"
+$SSH $SSHOPTS "$USER@$NODE" "mkdir -p ~/$RDIR/lib ~/$RDIR/scenes ~/$RDIR/output/anim && rm -f ~/$RDIR/output/anim/*.png"
+$SCP $SSHOPTS "$HERE/gpu_enable.py" "$USER@$NODE:~/$RDIR/" >/dev/null
+$SCP $SSHOPTS "$HERE/lib/retro90s_blender.py" "$USER@$NODE:~/$RDIR/lib/" >/dev/null
+$SCP $SSHOPTS "$SCENE" "$USER@$NODE:~/$RDIR/scenes/" >/dev/null
+
+echo ">> [gpu] rendering $FRAMES frames on RTX 5070 (OptiX)"
+$SSH $SSHOPTS "$USER@$NODE" \
+  "cd ~/$RDIR && FD_FRAMES=$FRAMES $RBLENDER -b -P gpu_enable.py -P scenes/$(basename "$SCENE") 2>&1 | grep -iE 'OPTIX|Saved|Error' | tail -3"
+
+echo ">> [gpu] pulling frames"
+fdir="$HERE/frames/gpu_anim"; rm -rf "$fdir"; mkdir -p "$fdir"
+$SCP $SSHOPTS "$USER@$NODE:~/$RDIR/output/anim/*.png" "$fdir/" >/dev/null
+
+echo ">> [gpu] encoding mp4"
+mkdir -p "$(dirname "$OUT")"
+ffmpeg -y -framerate "$FPS" -pattern_type glob -i "$fdir/*.png" \
+  -c:v libx264 -pix_fmt yuv420p -crf 18 "$OUT" -loglevel error
+[ -f "$OUT" ] || { echo ">> [gpu] FAILED" >&2; exit 1; }
+echo ">> [gpu] $OUT"

--- a/scenes/blender_anim.py
+++ b/scenes/blender_anim.py
@@ -1,0 +1,38 @@
+"""blender_anim.py — orbiting retro90s hero scene for the GPU animation lane.
+Animated sibling of scenes/blender_hero.py: a camera orbits the chrome/glass/
+plastic trio over a reflective checkerboard with fractal mountains.
+
+Run:  FD_FRAMES=72 blender -b -P gpu_enable.py -P scenes/blender_anim.py
+Frames land in ./output/anim/ (f0001.png ...). FD_FRAMES sets the orbit length.
+"""
+import os, sys
+
+_HERE = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for cand in (os.path.join(_HERE, "lib"),
+             os.path.expanduser("~/feverdream/lib"),
+             os.path.expanduser("~/feverdream")):
+    if os.path.isdir(cand):
+        sys.path.append(cand)
+
+from retro90s_blender import *   # noqa
+
+FRAMES = int(os.environ.get("FD_FRAMES", "72"))
+
+retro_reset()
+retro_sky_gradient((0.15, 0.20, 0.55), (1.0, 0.55, 0.25))
+retro_sun((-0.6, 0.7, -0.4), (1.0, 0.92, 0.78), energy=5.0)
+retro_fractal_terrain(height=7.0, scale_xz=22.0, loc=(0, 60, -0.3), extent=80)
+retro_checker_floor((0.9, 0.9, 0.95), (0.08, 0.08, 0.12), reflect=0.4, cell=2.0)
+
+retro_sphere((0, 6, 2.2), 2.2, retro_chrome((0.85, 0.88, 0.95)))
+retro_sphere((-4, 9, 1.6), 1.6, retro_glass((0.2, 0.9, 0.6)))
+retro_torus((4.5, 8, 1.6), 1.6, 0.5, retro_plastic((0.9, 0.12, 0.12)),
+            rot_deg=(70, 0, 0))
+
+# camera orbits the hero trio (centered ~ (0,7))
+retro_orbit_camera(orbit_radius=11, cam_height=4.5, target=(0, 7, 2.0),
+                   frames=FRAMES)
+
+out_dir = os.path.join(os.getcwd(), "output", "anim")
+retro_render_anim(out_dir, samples=96)
+print(f"[blender_anim] rendered {FRAMES} frames -> {out_dir}")


### PR DESCRIPTION
Adds the **GPU animation lane** so the 5070 (or any OptiX node) outputs orbiting
retro-CGI mp4s — the speed companion to the POV-Ray/CPU `animate.sh`.

## What's here
- `scenes/blender_anim.py` — orbiting hero scene using `retro_orbit_camera()` +
  `retro_render_anim()` from the ported look library. Orbit length = `FD_FRAMES`.
- `make_video_gpu.sh` — stages the look lib + scene to the render node, renders
  the frame sequence on GPU (Cycles/OptiX), pulls frames back, ffmpeg-encodes.

## Verified
On `.106` RTX 5070 via OptiX: 16 frames @ 1280×720 → mp4, ~2.6s/frame.
Same prompt→scene→deterministic-render pattern as the rest of the pipeline —
coherent across frames, far cheaper than diffusion video gen.

## Notes
- Auth: keyless ssh by default; `RETRO_GPU_PASS` enables sshpass for quick tests.
- Closes the "Blender GPU animation lane" feverdream bounty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)