### PR TITLE
Add Bryce-valley + ReBoot grid-tunnel scene templates

### DIFF
--- a/scenes/templates/bryce_valley.pov
+++ b/scenes/templates/bryce_valley.pov
@@ -1,0 +1,15 @@
+// bryce_valley.pov — Bryce-style fractal valley at sunset with glass spheres.
+// Template for the feverdream generator to re-dress (swap colors/objects).
+#include "retro90s.inc"
+
+Retro_Sky_Gradient(rgb <0.10,0.16,0.45>, rgb <1.0,0.50,0.20>)
+Retro_Sun(<-0.5,0.6,-0.5>, rgb <1.0,0.9,0.72>)
+
+Retro_Fractal_Terrain(11, 26, Retro_Terrain_Texture())
+Retro_Checker_Floor(rgb <0.85,0.86,0.92>, rgb <0.10,0.10,0.16>, 0.3)
+
+sphere { <-3,2,8>, 2.0 Retro_Glass(rgb <0.3,0.7,1.0>) }
+sphere { < 3,1.5,7>, 1.5 Retro_Chrome(rgb <0.9,0.9,0.95>) }
+sphere { < 0,1.0,5>, 1.0 Retro_Glass(rgb <1.0,0.4,0.6>) }
+
+Retro_Camera(<0,3,-3>, <0,2,7>)

--- a/scenes/templates/grid_tunnel.pov
+++ b/scenes/templates/grid_tunnel.pov
@@ -1,0 +1,13 @@
+// grid_tunnel.pov — ReBoot-style neon grid floor receding to a twilight horizon.
+// Template for the feverdream generator to re-dress.
+#include "retro90s.inc"
+
+Retro_Sky_Gradient(rgb <0.02,0.02,0.10>, rgb <0.6,0.1,0.8>)
+Retro_Sun(<0.0,0.6,-0.6>, rgb <0.8,0.85,1.0>)
+Retro_Grid_Floor(rgb <0.2,1.0,0.9>, rgb <0.03,0.03,0.08>, 2.0)
+
+sphere { <-3,1.6,9>, 1.6 Retro_Chrome(rgb <0.9,0.9,1.0>) }
+sphere { < 3,1.6,9>, 1.6 Retro_Glass(rgb <1.0,0.2,0.8>) }
+box { <-1,0,12>, <1,3,13> Retro_Plastic(rgb <0.1,0.9,1.0>) }
+
+Retro_Camera(<0,2.5,-2>, <0,1.5,10>)


### PR DESCRIPTION
Two hand-authored `scenes/templates/*.pov` for the feverdream generator to re-dress — both render cleanly via `render.sh`. Partial fill of rustchain-bounties feverdream template bounty (#13476).

- `bryce_valley.pov` — fractal valley at sunset with glass + chrome spheres
- `grid_tunnel.pov` — ReBoot-style neon grid floor receding to a twilight horizon

First contribution to feverdream 🌀

🤖 Generated with [Claude Code](https://claude.com/claude-code)