### PR TITLE
Add glass-city skyline + chrome-rings scene templates

### DIFF
--- a/scenes/templates/chrome_rings.pov
+++ b/scenes/templates/chrome_rings.pov
@@ -1,0 +1,13 @@
+// chrome_rings.pov — interlocked chrome tori hero shot, the demo-reel classic.
+// Template for the feverdream generator to re-dress.
+#include "retro90s.inc"
+
+Retro_Sky_Gradient(rgb <0.12,0.14,0.40>, rgb <1.0,0.6,0.3>)
+Retro_Sun(<-0.4,0.8,-0.4>, rgb <1.0,0.95,0.8>)
+Retro_Checker_Floor(rgb <0.92,0.92,0.96>, rgb <0.07,0.07,0.11>, 0.5)
+
+torus { 2.0,0.45 Retro_Chrome(rgb <0.88,0.90,0.96>) rotate x*80 translate <-1.4,2.2,7> }
+torus { 2.0,0.45 Retro_Chrome(rgb <0.88,0.90,0.96>) rotate <80,0,60> translate < 1.4,2.2,7> }
+sphere { <0,1.0,4>, 1.0 Retro_Glass(rgb <1.0,0.5,0.2>) }
+
+Retro_Camera(<0,3,-3.5>, <0,2.2,7>)

--- a/scenes/templates/glass_city.pov
+++ b/scenes/templates/glass_city.pov
@@ -1,0 +1,17 @@
+// glass_city.pov — refractive glass skyline on a reflective checkerboard.
+// Template for the feverdream generator to re-dress.
+#include "retro90s.inc"
+
+Retro_Sky_Gradient(rgb <0.08,0.10,0.30>, rgb <0.9,0.45,0.7>)
+Retro_Sun(<0.6,0.7,-0.3>, rgb <1.0,0.95,0.85>)
+Retro_Checker_Floor(rgb <0.9,0.9,0.95>, rgb <0.06,0.06,0.10>, 0.45)
+
+// Retro_Glass already emits texture{} + interior{}, so apply it inline per box.
+box { <-6,0,6>, <-4,7,8>    Retro_Glass(rgb <0.4,0.9,0.8>) }
+box { <-3,0,9>, <-1,11,11>  Retro_Glass(rgb <0.4,0.9,0.8>) }
+box { < 0,0,7>, < 2,9,9>    Retro_Glass(rgb <0.5,0.8,1.0>) }
+box { < 3,0,10>,< 5,6,12>   Retro_Glass(rgb <0.4,0.9,0.8>) }
+box { < 5.5,0,7>,<7.5,13,9> Retro_Glass(rgb <0.6,0.9,0.7>) }
+sphere { <0,5,3>, 1.4 Retro_Chrome(rgb <0.9,0.9,1.0>) }
+
+Retro_Camera(<0,4,-4>, <0,5,8>)


### PR DESCRIPTION
Two more hand-authored `scenes/templates/*.pov` for the feverdream generator — both render cleanly via `render.sh`. Together with #2 this fills most of the feverdream template bounty (#13476).

- `glass_city.pov` — refractive glass skyline on a reflective checkerboard
- `chrome_rings.pov` — interlocked chrome tori, the demo-reel classic

For the fever dream 🌀✨

🤖 Generated with [Claude Code](https://claude.com/claude-code)