### PR TITLE
fix: use rustchain_crypto for Ed25519 signatures

### DIFF
--- a/addon/feverdream_order.py
+++ b/addon/feverdream_order.py
@@ -120,9 +120,18 @@ def cmd_order(args):
         return 0
 
     # Create and sign transfer
+    try:
+        import rustchain_crypto
+    except ImportError:
+        try:
+            from rustchain_mcp import rustchain_crypto
+        except ImportError:
+            print("❌ rustchain_crypto not found. Please install rustchain-mcp.")
+            return 1
+
     nonce = str(int(time.time() * 1000))
     msg = f"{address}feverdream_studio{cost}{nonce}"
-    signature = sha256(msg + privkey)
+    signature = rustchain_crypto.sign_message(msg.encode('utf-8'), privkey)
 
     tx = {
         "from_address": address,


### PR DESCRIPTION
Fixes #14.

Replaced the dummy SHA256 signature in `feverdream_order.py` with the Ed25519 signature implementation from `rustchain_mcp.rustchain_crypto`. This generates valid transactions for the RustChain network when using the CLI tool.