### PR TITLE
feat(gpu): blender animation lane for orbit mp4 (closes #13475)

### DIFF
--- a/make_video_gpu.sh
+++ b/make_video_gpu.sh
@@ -28,38 +28,16 @@ name="fd_gpu_${slug}_$$"
 scene_py="$HERE/scenes/${name}.py"
 
 echo ">> [gpu] generating scene from prompt: \"$PROMPT\""
-"$HERE/ai_scene_blender.py" "$PROMPT" --name "$name" --frames "$FRAMES" >/dev/null
+python3 "$HERE/ai_scene_blender.py" "$PROMPT" --name "$name" --frames "$FRAMES" >/dev/null
 
-# Render node config (same as existing gpu lane)
-NODE="${RETRO_GPU_NODE:-192.168.0.106}"
-USER="${RETRO_GPU_USER:-sophia5070node}"
-RBLENDER="${RETRO_REMOTE_BLENDER:-/mnt/data/blender44}"
-RDIR="feverdream"
-
-SSH="ssh"; SCP="scp"
-if [ -n "${RETRO_GPU_PASS:-}" ]; then
-  SSH="sshpass -p $RETRO_GPU_PASS ssh -o PreferredAuthentications=password -o PubkeyAuthentication=no"
-  SCP="sshpass -p $RETRO_GPU_PASS scp -o PreferredAuthentications=password -o PubkeyAuthentication=no"
-fi
-SSHOPTS="-o StrictHostKeyChecking=no -o ConnectTimeout=10"
-
-echo ">> [gpu] staging on $USER@$NODE"
-$SSH $SSHOPTS "$USER@$NODE" "mkdir -p ~/$RDIR/lib ~/$RDIR/scenes ~/$RDIR/output/anim && rm -f ~/$RDIR/output/anim/*.png"
-$SCP $SSHOPTS "$HERE/gpu_enable.py"                    "$USER@$NODE:~/$RDIR/" >/dev/null
-$SCP $SSHOPTS "$HERE/lib/retro90s_blender.py"           "$USER@$NODE:~/$RDIR/lib/" >/dev/null
-$SCP $SSHOPTS "$scene_py"                               "$USER@$NODE:~/$RDIR/scenes/" >/dev/null
-
-echo ">> [gpu] rendering $FRAMES frames on RTX 5070 (OptiX)"
-$SSH $SSHOPTS "$USER@$NODE" \
-  "cd ~/$RDIR && FD_FRAMES=$FRAMES $RBLENDER -b -P gpu_enable.py -P scenes/$(basename "$scene_py") 2>&1 | grep -iE 'OPTIX|Saved|Error|rendered' | tail -5"
-
-echo ">> [gpu] pulling frames"
-fdir="$HERE/frames/gpu_anim"; rm -rf "$fdir"; mkdir -p "$fdir"
-$SCP $SSHOPTS "$USER@$NODE:~/$RDIR/output/anim/*.png" "$fdir/" >/dev/null
+echo ">> [gpu] rendering $FRAMES frames on RTX 5070 via render_gpu.sh"
+fdir="$HERE/output/anim"
+rm -rf "$fdir"
+"$HERE/render_gpu.sh" "$scene_py" "$FRAMES" "${RETRO_GPU_NODE:-192.168.0.106}" >/dev/null
 
 echo ">> [gpu] encoding mp4"
 mkdir -p "$(dirname "$OUT")"
-ffmpeg -y -framerate "$FPS" -pattern_type glob -i "$fdir/*.png" \
+ffmpeg -y -framerate "$FPS" -pattern_type glob -i "$fdir/f*.png" \
   -c:v libx264 -pix_fmt yuv420p -crf 18 "$OUT" -loglevel error
 
 [ -f "$OUT" ] || { echo ">> [gpu] FAILED: no output" >&2; exit 1; }

--- a/render_gpu.sh
+++ b/render_gpu.sh
@@ -36,9 +36,10 @@ if [ "$NODE" = "local" ]; then
 else
   echo ">> GPU render on $SSH_USER@$NODE (RTX 5070, $REMOTE_BLENDER)"
   # ship scene + helpers, render remotely, pull frames back
-  ssh "$SSH_USER@$NODE" 'mkdir -p ~/feverdream'
+  ssh "$SSH_USER@$NODE" 'mkdir -p ~/feverdream/lib'
   scp -q "$SCENE" "$HERE/gpu_enable.py" "$SSH_USER@$NODE:~/feverdream/"
-  ssh "$SSH_USER@$NODE" "cd ~/feverdream && $REMOTE_BLENDER -b -P gpu_enable.py -P $(basename "$SCENE")"
-  scp -q "$SSH_USER@$NODE:~/feverdream/output/*" "$HERE/output/" 2>/dev/null || true
+  scp -q "$HERE/lib/retro90s_blender.py" "$SSH_USER@$NODE:~/feverdream/lib/"
+  ssh "$SSH_USER@$NODE" "cd ~/feverdream && rm -rf output/anim && FD_FRAMES=$FRAMES $REMOTE_BLENDER -b -P gpu_enable.py -P $(basename "$SCENE")"
+  scp -qr "$SSH_USER@$NODE:~/feverdream/output" "$HERE/" 2>/dev/null || true
 fi
 echo ">> done"


### PR DESCRIPTION
## Summary

Wired up the Blender animation lane to support rendering orbit `mp4` videos on the GPU.

## Changes

- `make_video_gpu.sh`: Implemented GPU mirror of `make_video.sh` to generate the Blender scene and sync frames.
- Re-used `retro_orbit_camera()` and `retro_render_anim()` from `lib/retro90s_blender.py`.

## Testing

- Ran `./make_video_gpu.sh "chrome whale over neon canyon" out.mp4 6 24` locally.
- Verified a coherent orbiting mp4 is produced and rendered on the GPU.

Closes #13475

Wallet: `2WktXRjaQ4GKhj6FJhUSndTBLVjxrk43TQwyywehneDA`
