### PR TITLE
Validate LLM scenes against the macro contract before rendering

### DIFF
--- a/ai_scene.py
+++ b/ai_scene.py
@@ -17,6 +17,8 @@ Backend is any OpenAI-compatible /v1/chat/completions endpoint.
 import argparse, json, os, re, subprocess, sys, time, urllib.request
 
 HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+from fd_validate import validate_scene   # pre-render macro-contract check
 LIB  = os.path.join(HERE, "lib")
 SCENES = os.path.join(HERE, "scenes")
 
@@ -192,6 +194,27 @@ def main():
             f.write(sdl)
         print(f"[ai] wrote {pov_path} ({len(sdl)} bytes, {time.time()-t0:.1f}s)",
               file=sys.stderr)
+
+        # Cheap contract check before the expensive raytrace: catch invented
+        # macros, wrong arg counts, redefinitions, and truncated output now, and
+        # feed the exact violations back to the model instead of burning a render.
+        vr = validate_scene(sdl, LIB)
+        for w in vr["warnings"]:
+            print(f"[ai] warn: {w}", file=sys.stderr)
+        if not vr["ok"]:
+            print("[ai] scene rejected before render:\n  " +
+                  "\n  ".join(vr["errors"]), file=sys.stderr)
+            if attempt <= args.retries:
+                user_prompt = (
+                    f"{args.prompt}\n\nYour previous scene was REJECTED before "
+                    "rendering for these contract violations:\n- "
+                    + "\n- ".join(vr["errors"])
+                    + "\n\nUse ONLY the library Retro_* macros with the exact argument "
+                      'counts, keep #include "retro90s.inc" as the first line, and '
+                      "balance every brace. Return ONLY corrected source.")
+                continue
+            print("[ai] giving up: scene never passed validation", file=sys.stderr)
+            sys.exit(1)
 
         if not args.render:
             print(pov_path); return

--- a/fd_validate.py
+++ b/fd_validate.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""
+fd_validate.py — pre-render validator for LLM-authored retro90s POV-Ray scenes.
+
+The pipeline's expensive step is the raytrace. A small model writing SDL will
+sometimes invent a macro, pass the wrong number of arguments, redefine a library
+macro, or stop mid-scene with unbalanced braces — and today none of that is
+caught until POV-Ray fails (or worse, renders garbage). This checks a scene
+against the macro contract in `lib/*.inc` first, so ai_scene.py can reject or
+feed the exact errors back to the model instead of burning a render.
+
+The known-macro set and each macro's arity are harvested from `lib/*.inc` at
+run time, so this never drifts from the library.
+
+    ./fd_validate.py scene.pov            # exit 0 = ok, 1 = errors
+    validate_scene(source, lib_dir)       # -> {ok, errors, warnings, macros_used}
+"""
+import os
+import re
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+DEFAULT_LIB = os.path.join(HERE, "lib")
+
+_OPEN = {"(": ")", "[": "]", "{": "}", "<": ">"}
+_CLOSE = {v: k for k, v in _OPEN.items()}
+
+
+def strip_noise(src: str) -> str:
+    """Remove // and /* */ comments and "double-quoted strings" so brace/paren
+    scanning and macro detection never trip over text inside them."""
+    src = re.sub(r"/\*.*?\*/", " ", src, flags=re.DOTALL)
+    src = re.sub(r"//[^\n]*", " ", src)
+    src = re.sub(r'"(?:[^"\\]|\\.)*"', '""', src)
+    return src
+
+
+def harvest_macros(lib_dir: str) -> dict:
+    """Return {macro_name: arg_count} for every #macro defined in lib/*.inc."""
+    macros = {}
+    if not os.path.isdir(lib_dir):
+        return macros
+    for fn in sorted(os.listdir(lib_dir)):
+        if not fn.endswith(".inc"):
+            continue
+        text = strip_noise(open(os.path.join(lib_dir, fn), encoding="utf-8",
+                                 errors="replace").read())
+        for m in re.finditer(r"#macro\s+([A-Za-z_]\w*)\s*\(([^)]*)\)", text):
+            name, args = m.group(1), m.group(2).strip()
+            macros[name] = 0 if args == "" else args.count(",") + 1
+    return macros
+
+
+def _split_top_level_args(inner: str):
+    """Split a macro call's argument text on TOP-LEVEL commas only — commas
+    inside <vectors>, nested (calls), {blocks} or [arrays] do not separate args."""
+    args, depth, cur = [], 0, []
+    for ch in inner:
+        if ch in _OPEN:
+            depth += 1
+        elif ch in _CLOSE:
+            depth = max(0, depth - 1)
+        if ch == "," and depth == 0:
+            args.append("".join(cur))
+            cur = []
+        else:
+            cur.append(ch)
+    tail = "".join(cur).strip()
+    if tail or args:
+        args.append(tail)
+    return [a.strip() for a in args]
+
+
+def _find_calls(src: str):
+    """Yield (name, arg_text, ok_balanced) for every `Identifier( ... )` whose
+    name starts with an uppercase letter (library macros are Capitalized; POV
+    built-ins are lowercase). Uses balanced-paren matching to grab the arg text."""
+    for m in re.finditer(r"\b([A-Z]\w*)\s*\(", src):
+        name = m.group(1)
+        i = m.end() - 1  # at the '('
+        depth, j = 0, i
+        n = len(src)
+        while j < n:
+            c = src[j]
+            if c == "(":
+                depth += 1
+            elif c == ")":
+                depth -= 1
+                if depth == 0:
+                    yield name, src[i + 1:j], True
+                    break
+            j += 1
+        else:
+            yield name, src[i + 1:], False
+
+
+def validate_scene(source: str, lib_dir: str = DEFAULT_LIB) -> dict:
+    macros = harvest_macros(lib_dir)
+    errors, warnings, used = [], [], []
+    clean = strip_noise(source)
+
+    # 1. must pull in the library
+    if '#include "retro90s.inc"' not in source and "#include \"retro90s.inc\"" not in source:
+        errors.append('missing `#include "retro90s.inc"` (must be the first line)')
+
+    # 2. the scene must not redefine library macros
+    for m in re.finditer(r"#macro\s+([A-Za-z_]\w*)", clean):
+        if m.group(1) in macros:
+            errors.append(f"redefines library macro `{m.group(1)}` (forbidden)")
+        else:
+            warnings.append(f"defines its own macro `{m.group(1)}` (scenes should compose, not define)")
+
+    # 3. balanced braces/parens overall (catch truncated output)
+    for op, name in ((("{", "}"), "braces"), (("(", ")"), "parens")):
+        if clean.count(op[0]) != clean.count(op[1]):
+            errors.append(f"unbalanced {name}: {clean.count(op[0])} `{op[0]}` vs {clean.count(op[1])} `{op[1]}`")
+
+    # 4. every Capitalized(...) call must be a known macro with the right arity
+    cams = 0
+    for name, arg_text, balanced in _find_calls(clean):
+        if not balanced:
+            errors.append(f"`{name}(` is never closed (truncated scene?)")
+            continue
+        if name not in macros:
+            errors.append(f"unknown macro `{name}` — not defined in lib/*.inc")
+            continue
+        used.append(name)
+        if name in ("Retro_Camera", "Retro_Orbit_Camera"):
+            cams += 1
+        got = len(_split_top_level_args(arg_text)) if arg_text.strip() else 0
+        want = macros[name]
+        if got != want:
+            errors.append(f"`{name}` takes {want} arg(s), got {got}: ({arg_text.strip()[:60]})")
+
+    # 5. exactly one hero camera is expected
+    if cams == 0:
+        warnings.append("no Retro_Camera / Retro_Orbit_Camera — POV will use a default view")
+    elif cams > 1:
+        warnings.append(f"{cams} cameras defined — the last one wins")
+
+    return {"ok": not errors, "errors": errors, "warnings": warnings,
+            "macros_used": sorted(set(used))}
+
+
+def main(argv):
+    if len(argv) < 2:
+        print("usage: fd_validate.py scene.pov [--lib DIR]", file=sys.stderr)
+        return 2
+    lib = DEFAULT_LIB
+    if "--lib" in argv:
+        lib = argv[argv.index("--lib") + 1]
+    src = open(argv[1], encoding="utf-8", errors="replace").read()
+    r = validate_scene(src, lib)
+    for e in r["errors"]:
+        print(f"  ERROR: {e}")
+    for w in r["warnings"]:
+        print(f"  warn:  {w}")
+    print(f"{'OK' if r['ok'] else 'INVALID'} — {argv[1]} "
+          f"(macros: {', '.join(r['macros_used']) or 'none'})")
+    return 0 if r["ok"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/test_fd_validate.py
+++ b/test_fd_validate.py
@@ -1,0 +1,39 @@
+import sys; sys.path.insert(0, ".")
+from fd_validate import validate_scene
+LIB="lib"
+def has_err(src, needle):
+    r=validate_scene(src, LIB)
+    hit=any(needle in e for e in r["errors"])
+    print(f"  [{'PASS' if hit else 'FAIL'}] catches '{needle}': errors={r['errors'][:2]}")
+    return hit
+
+GOOD = '''#include "retro90s.inc"
+Retro_Sky_Gradient(rgb <0.1,0.2,0.5>, rgb <1.0,0.5,0.2>)
+Retro_Sun(<-0.6,0.7,-0.4>, rgb <1,0.9,0.8>)
+Retro_Fractal_Terrain(14, 22, Retro_Terrain_Texture())
+sphere { <0,2,6>, 2 Retro_Chrome(rgb <0.8,0.9,1.0>) }
+Retro_Camera(<0,4,-10>, <0,1,4>)
+'''
+fails=0
+# baseline good scene must be OK (vectors' internal commas must NOT miscount args)
+r=validate_scene(GOOD, LIB)
+print(f"  [{'PASS' if r['ok'] else 'FAIL'}] good scene valid (arg-count vector-safe): {r['errors']}")
+fails += 0 if r["ok"] else 1
+
+fails += 0 if has_err(GOOD.replace("Retro_Fractal_Terrain(14, 22, Retro_Terrain_Texture())",
+                                   "Retro_Water(<0,0,0>, 5)"), "unknown macro `Retro_Water`") else 1
+fails += 0 if has_err(GOOD.replace("Retro_Chrome(rgb <0.8,0.9,1.0>)",
+                                   "Retro_Chrome(rgb <0.8,0.9,1.0>, 5)"), "Retro_Chrome` takes 1") else 1
+fails += 0 if has_err("#macro Retro_Chrome(t)\n#end\n"+GOOD, "redefines library macro `Retro_Chrome`") else 1
+fails += 0 if has_err(GOOD.replace("Retro_Camera(<0,4,-10>, <0,1,4>)","sphere { <0,0,0>, 1"), "unbalanced") else 1
+fails += 0 if has_err(GOOD.replace('#include "retro90s.inc"\n',''), "missing `#include") else 1
+# truncated: unclosed macro call
+fails += 0 if has_err('#include "retro90s.inc"\nRetro_Sun(<0,1,0>, rgb <1,1,1', "never closed") else 1
+# camera warning (not an error) — good scene w/o camera should still be ok=True but warn
+nocam=validate_scene(GOOD.replace("Retro_Camera(<0,4,-10>, <0,1,4>)\n",""), LIB)
+cam_warn=any("no Retro_Camera" in w for w in nocam["warnings"])
+print(f"  [{'PASS' if (nocam['ok'] and cam_warn) else 'FAIL'}] no-camera is a warning not an error")
+fails += 0 if (nocam["ok"] and cam_warn) else 1
+
+print(f"\n{'ALL VALIDATOR TESTS PASSED' if fails==0 else str(fails)+' TEST(S) FAILED'}")
+sys.exit(1 if fails else 0)


### PR DESCRIPTION
## What

The raytrace is the expensive step, but nothing checked the model's output first. When the small model invents a macro, passes the wrong number of arguments, redefines a library macro, or stops mid-scene with unbalanced braces, that was only discovered when POV-Ray failed (or quietly rendered garbage) — one wasted render at a time.

`fd_validate.py` checks a scene against the `lib/*.inc` macro contract before rendering:
- **Self-syncing**: harvests every macro name and arity from `lib/*.inc` at run time, so it never drifts from the library (retro90s, characters, starcraft, warcraft, etc. all covered).
- Requires `#include "retro90s.inc"`.
- Rejects redefinition of a library macro.
- Balanced braces and parens (catches truncated output).
- Every `Capitalized(...)` call must resolve to a known macro with the **right argument count**. Counting is depth-aware, so commas inside `<vectors>` and nested calls like `Retro_Fractal_Terrain(14, 22, Retro_Terrain_Texture())` do not miscount.
- A missing camera is a warning, not an error.

`ai_scene.py` now runs this after generating and before rendering: on a violation it feeds the **exact** errors back to the model for the next attempt (cheaper and more precise than waiting for POV-Ray to fail), and refuses to render a scene it already knows is broken.

## Verification
- All six existing sample scenes in `scenes/` validate clean — no false positives (it correctly resolves character macros from the other includes).
- `test_fd_validate.py` covers the vector-safe good scene plus each rejection class: unknown macro, wrong arity, redefinition, unbalanced braces, missing include, truncated call, and that a missing camera stays a warning.
- `ai_scene.py` compiles and imports the validator cleanly (no behavior change on valid scenes).

Pure Python, no new dependency.