### PR TITLE
Beyond-the-Mind's-Eye macro library + demo scenes

### DIFF
--- a/lib/beyond90s.inc
+++ b/lib/beyond90s.inc
@@ -1,0 +1,231 @@
+// ============================================================
+//  beyond90s.inc  —  "Beyond the Mind's Eye" (1992) look pack
+//  Elyan Labs retro-cgi pipeline.  POV-Ray 3.7 SDL.
+//
+//  Companion to retro90s.inc — adds the signature early-CGI
+//  compilation vibe: three-stop sunset gradient skies, dark
+//  mesa/butte horizon silhouettes, polished GOLD chrome,
+//  starfields, glowing planets, and product-viz plinths.
+//
+//  Conventions match retro90s.inc: pure macros, no camera or
+//  global_settings here. Include retro90s.inc FIRST in scenes
+//  (it owns global_settings); this file only defines macros.
+// ============================================================
+
+// ============================================================
+//  SKY  —  the signature THREE-stop sunset gradient
+// ============================================================
+
+// The Mind's Eye sunset: deep violet/blue zenith, a hot
+// orange/magenta band, and a yellow glow hugging the horizon.
+// Below the horizon stays c_glow so chrome/floors reflect warmth.
+//   c_top  = zenith color        (e.g. rgb <0.10,0.05,0.35>)
+//   c_band = hot mid band        (e.g. rgb <1.00,0.30,0.45>)
+//   c_glow = horizon glow        (e.g. rgb <1.00,0.85,0.30>)
+#macro Beyond_Sunset_Sky(c_top, c_band, c_glow)
+  sky_sphere {
+    pigment {
+      gradient y
+      color_map {
+        [0.00  c_glow]     // everything below the horizon: warm glow
+        [0.50  c_glow]     // horizon line
+        [0.545 c_band]     // hot orange/magenta band hugs the horizon
+        [0.585 c_band]
+        [0.66  c_top]      // deep violet/blue takes over fast (so the
+        [1.00  c_top]      // top stop is visible in a level camera frame)
+      }
+      scale 2 translate -1
+    }
+  }
+#end
+
+// ============================================================
+//  HORIZON  —  dark mesa/butte silhouettes in a ring
+// ============================================================
+
+// A ring of `butte_count` dark angular buttes at distance `dist`,
+// standing on y=0, up to `height` tall. Widths/heights vary
+// deterministically per butte (sin-hash) so the skyline reads
+// natural but renders identically every frame of an animation.
+// Emits a union — wrap in object{} to rotate/translate it.
+// (NB: params avoid POV reserved words like `count`.)
+#macro Beyond_Mesa_Ring(butte_color, butte_count, dist, height)
+  union {
+    #local i = 0;
+    #while (i < butte_count)
+      // pseudo-random (but deterministic) jitter per butte
+      #local ang = 360*i/butte_count + 8*sin(i*12.9898);
+      #local h   = height * (0.55 + 0.45*abs(sin(i*3.7 + 1.3)));
+      #local w   = (dist*pi/butte_count) * (0.9 + 0.5*abs(cos(i*2.3)));
+      #local d   = w*0.5;
+      union {
+        // main butte slab
+        box { <-w/2, 0, -d/2>, <w/2, h, d/2> }
+        // stepped cap — the classic flat-top butte profile
+        box { <-w*0.30, h*0.98, -d*0.40>, <w*0.30, h*1.22, d*0.40> }
+        // talus skirt at the base
+        cone { <0,0,0>, w*0.75, <0, h*0.45, 0>, w*0.28 }
+        translate <0, 0, dist>
+        rotate y*ang
+      }
+      #local i = i + 1;
+    #end
+    pigment { color butte_color }
+    // near-flat shading: buttes should read as silhouettes
+    finish { ambient 0.25 diffuse 0.35 }
+  }
+#end
+
+// ============================================================
+//  MATERIALS  —  polished gold chrome
+// ============================================================
+
+// Warm metallic GOLD chrome — the iconic posing-figure material.
+// tint multiplies the gold base; pass rgb <1,1,1> for pure gold,
+// or push it warmer/cooler. Needs a bright sky to mirror (same
+// rule as Retro_Chrome).
+#macro Beyond_Gold(tint)
+  texture {
+    pigment { color tint * <1.00, 0.78, 0.34> }
+    finish {
+      ambient 0.12 diffuse 0.30
+      brilliance 4
+      reflection { 0.65 metallic }
+      specular 1.0 roughness 0.0015
+      metallic
+    }
+  }
+#end
+
+// ============================================================
+//  SPACE  —  starfield + glowing planet
+// ============================================================
+
+// Points of light on a huge inward-facing sphere (radius 900,
+// so it sits inside the sky_sphere but beyond any scene geometry).
+//   star_density = 0..1  (0 = very sparse, 1 = dense field)
+//   star_color   = star tint (e.g. rgb <1,0.95,0.85>)
+// no_shadow so it never dapples the sun; emission so stars stay
+// bright regardless of scene lighting.
+#macro Beyond_Starfield(star_density, star_color)
+  sphere {
+    <0,0,0>, 900
+    hollow no_shadow
+    texture {
+      pigment {
+        granite
+        color_map {
+          [0.00                      rgbt <0,0,0,1>]
+          [0.78 - 0.18*star_density  rgbt <0,0,0,1>]
+          [0.80 - 0.18*star_density  color star_color]
+          [1.00                      color star_color]
+        }
+        scale 25
+      }
+      finish { emission 1.0 ambient 0 diffuse 0 }
+    }
+  }
+#end
+
+// Glowing planet: a softly banded lit sphere wrapped in an
+// emissive media atmosphere that brightens at the limb (rim glow).
+// Emits a union centered at the origin — wrap in object{} and
+// translate it into the sky:  object { Beyond_Planet(9, rgb<1,0.62,0.2>,
+// rgb<1,0.45,0.15>) translate <-30,40,80> }
+#macro Beyond_Planet(p_radius, surface_color, glow_color)
+  union {
+    // the lit body — subtle turbulent banding, soft shading
+    sphere {
+      <0,0,0>, p_radius
+      texture {
+        pigment {
+          gradient y
+          turbulence 0.55
+          color_map {
+            [0.00 color surface_color*0.55]
+            [0.45 color surface_color]
+            [0.62 color surface_color*1.25]
+            [1.00 color surface_color*0.70]
+          }
+          scale p_radius*0.6
+        }
+        finish { ambient 0.30 diffuse 0.75 specular 0.15 roughness 0.05 }
+      }
+    }
+    // emissive atmosphere shell — media path length peaks at the
+    // limb, so the rim glows brightest (view-independent, safe for
+    // orbit cameras). Emission scales with 1/p_radius so the glow
+    // strength is consistent across planet sizes.
+    sphere {
+      <0,0,0>, p_radius*1.22
+      hollow no_shadow
+      pigment { color rgbt <0,0,0,1> }
+      finish { ambient 0 diffuse 0 }
+      interior {
+        media {
+          emission glow_color * (1.6/p_radius)
+          density {
+            spherical
+            density_map {
+              [0.00 rgb 0.00]   // outer edge of atmosphere
+              [0.10 rgb 0.90]   // just off the limb: hottest
+              [0.18 rgb 0.15]   // planet surface — fades over the disc
+              [1.00 rgb 0.05]
+            }
+            scale p_radius*1.22
+          }
+        }
+      }
+    }
+  }
+#end
+
+// ============================================================
+//  PRODUCT VIZ  —  "3D PERSPECTIVE VIEW" turntable plinth
+// ============================================================
+
+// A dark display drum with a chrome trim ring and a glowing top
+// disc marked with radial turntable ticks. The plinth STANDS ON
+// y=0 (so it works with the Retro floors); its top surface is at
+// y = plinth_size*0.30 — translate the hero up by that amount:
+//   object { Beyond_Plinth(6, rgb <0.15,0.45,0.9>) }
+//   object { My_Hero translate <0, 6*0.30, 0> }
+//   plinth_size = plinth radius (param avoids POV reserved word `size`)
+//   top_color   = glowing display-top color (e.g. rgb <0.15,0.45,0.9>)
+// Emits a union — wrap in object{} to move it if needed.
+#macro Beyond_Plinth(plinth_size, top_color)
+  union {
+    // dark drum base
+    cylinder {
+      <0, 0, 0>, <0, plinth_size*0.25, 0>, plinth_size
+      pigment { color rgb <0.06, 0.06, 0.09> }
+      finish { ambient 0.15 diffuse 0.5 phong 0.5 phong_size 80 reflection { 0.10 } }
+    }
+    // chrome trim ring at the lip
+    torus {
+      plinth_size*0.97, plinth_size*0.045
+      pigment { color rgb <0.90, 0.90, 0.95> }
+      finish {
+        ambient 0.1 diffuse 0.25
+        reflection { 0.85 metallic }
+        specular 0.9 roughness 0.001
+        metallic
+      }
+      translate <0, plinth_size*0.25, 0>
+    }
+    // glowing display top with radial degree ticks
+    cylinder {
+      <0, plinth_size*0.25, 0>, <0, plinth_size*0.30, 0>, plinth_size*0.94
+      pigment {
+        radial frequency 24
+        color_map {
+          [0.00 color top_color*1.25]
+          [0.06 color top_color*1.25]
+          [0.06 color top_color*0.65]
+          [1.00 color top_color*0.65]
+        }
+      }
+      finish { ambient 0.45 diffuse 0.6 phong 0.6 phong_size 90 reflection { 0.08 } }
+    }
+  }
+#end

--- a/scenes/beyond_demo.pov
+++ b/scenes/beyond_demo.pov
@@ -1,0 +1,41 @@
+// ============================================================
+//  beyond_demo.pov — exercises every macro in beyond90s.inc
+//  A dusk desert product-viz tableau: three-stop sunset sky,
+//  mesa silhouettes, early stars, a glowing amber planet, and
+//  a gold hero figure on a "3D PERSPECTIVE VIEW" plinth.
+// ============================================================
+#include "retro90s.inc"
+#include "beyond90s.inc"
+
+// --- the signature three-stop sunset sky -------------------
+Beyond_Sunset_Sky(rgb <0.10, 0.05, 0.35>, rgb <1.00, 0.30, 0.45>, rgb <1.00, 0.85, 0.30>)
+
+// --- early stars coming out at dusk ------------------------
+Beyond_Starfield(0.20, rgb <1.00, 0.95, 0.85>)
+
+// --- dark buttes ringing the far horizon -------------------
+Beyond_Mesa_Ring(rgb <0.09, 0.04, 0.10>, 14, 260, 26)
+
+// --- desert floor -------------------------------------------
+plane { y, 0 Retro_Plastic(rgb <0.50, 0.28, 0.15>) }
+
+// --- glowing amber planet hanging in the sky ---------------
+object { Beyond_Planet(9, rgb <1.00, 0.62, 0.20>, rgb <1.00, 0.45, 0.15>) translate <-26, 32, 70> }
+
+// --- turntable plinth standing on the floor (top at y=1.8) --
+object { Beyond_Plinth(6, rgb <0.15, 0.45, 0.90>) }
+
+// --- gold hero figure posing on the plinth top --------------
+union {
+  cone   { <0, 0, 0>, 1.4, <0, 4.4, 0>, 0.6 }   // body
+  sphere { <0, 6.2, 0>, 2.0 }                    // head/orb
+  torus  { 3.1, 0.45 translate <0, 6.2, 0> }     // halo ring
+  Beyond_Gold(rgb <1, 1, 1>)
+  translate <0, 6*0.30, 0>                       // up onto the plinth top
+}
+
+// --- low warm sun raking in from behind the mesas ----------
+Retro_Sun(<0.4, 0.15, 1.0>, rgb <1.00, 0.72, 0.45>)
+
+// --- hero camera --------------------------------------------
+Retro_Orbit_Camera(25, 6.0, <0, 4.0, 0>)

--- a/scenes/concept_turntable.pov
+++ b/scenes/concept_turntable.pov
@@ -1,0 +1,81 @@
+// concept_turntable.pov — "Concept One: 3D Perspective View"
+// A Wavefront-demo product turntable: a sleek hot-orange concept vehicle with
+// chrome wheels and canopy, parked on a thin display plinth, slowly spinning
+// under a soft studio sky over a faint perspective grid. The camera holds a
+// fixed 3/4 hero angle so the turntable rotation reads. Pure 1992 product-viz.
+
+#include "retro90s.inc"
+
+// Soft studio sky — cool grey up top fading to a warm near-white horizon, the
+// classic seamless product-shot backdrop.
+Retro_Sky_Gradient(
+  rgb <0.42, 0.50, 0.64>,    // top: cool studio grey-blue
+  rgb <0.93, 0.91, 0.86>)    // horizon: warm seamless white
+
+// Warm key light, high and to the left — a soft product-shot key.
+Retro_Sun(<-0.55, 0.78, -0.30>, rgb <1.00, 0.95, 0.84>)
+
+// Faint technical perspective grid — the "3D PERSPECTIVE VIEW" Wavefront floor.
+Retro_Grid_Floor(rgb <0.32, 0.52, 0.72>, rgb <0.84, 0.86, 0.90>, 1.2)
+
+// --- palette -----------------------------------------------------------------
+#declare HotOrange = rgb <0.95, 0.45, 0.10>;   // bold concept-car orange
+#declare ChromeSil = rgb <0.85, 0.88, 0.95>;   // bright chrome
+#declare DarkTire  = rgb <0.10, 0.10, 0.12>;   // near-black tire
+
+// --- the display plinth: a thin rectangular box with a chrome trim edge ------
+box { <-2.7, 0.00, -2.1>, <2.7, 0.30, 2.1> Retro_Plastic(rgb <0.14, 0.15, 0.18>) }
+box { <-2.75, 0.30, -2.15>, <2.75, 0.38, 2.15> Retro_Chrome(ChromeSil) }  // chrome cap
+
+// --- the hero: a sleek concept vehicle, wrapped in a union that spins ---------
+union {
+  // Low sculptural body — a rounded superellipsoid slab, the concept form.
+  superellipsoid { <0.35, 0.55>
+    scale <2.05, 0.46, 0.98>
+    translate <0, 1.14, 0>
+    Retro_Plastic(HotOrange)
+  }
+  // Tapered nose wedge blended off the front (+x), for a low aggressive prow.
+  cone { <2.55, 1.08, 0>, 0.02, <1.4, 1.14, 0>, 0.62
+    scale <1, 0.7, 1> translate <0, 0.34, 0>
+    Retro_Plastic(HotOrange)
+  }
+  // Chrome bubble canopy set forward on the deck.
+  sphere { <0, 0, 0>, 1
+    scale <0.92, 0.42, 0.66>
+    translate <0.35, 1.52, 0>
+    Retro_Chrome(ChromeSil)
+  }
+  // Rear spoiler — a thin chrome wing on two little posts.
+  box { <-2.05, 1.60, -0.85>, <-1.75, 1.66, 0.85> Retro_Chrome(ChromeSil) }
+  cylinder { <-1.9, 1.40, -0.62>, <-1.9, 1.60, -0.62>, 0.05 Retro_Chrome(ChromeSil) }
+  cylinder { <-1.9, 1.40,  0.62>, <-1.9, 1.60,  0.62>, 0.05 Retro_Chrome(ChromeSil) }
+
+  // A bright chrome side accent strip down each flank.
+  box { <-1.7, 1.02, -1.00>, <1.9, 1.10, -0.94> Retro_Chrome(ChromeSil) }
+  box { <-1.7, 1.02,  0.94>, <1.9, 1.10,  1.00> Retro_Chrome(ChromeSil) }
+
+  // Headlights — small chrome pods at the prow.
+  sphere { <2.2, 1.16, -0.42>, 0.16 Retro_Chrome(ChromeSil) }
+  sphere { <2.2, 1.16,  0.42>, 0.16 Retro_Chrome(ChromeSil) }
+
+  // Four wheels — dark tires with bright chrome hubs, resting on the plinth.
+  #declare wx = 1.42;
+  #declare wz = 0.94;
+  #declare k = 0;
+  #while (k < 4)
+    #declare sx = wx * (1 - 2 * mod(k, 2));          // +x front / -x rear pairs
+    #declare sz = wz * (1 - 2 * div(k, 2));          // +z / -z sides
+    // tire (cylinder axle along z)
+    cylinder { <sx, 0.70, sz - 0.14>, <sx, 0.70, sz + 0.14>, 0.36 Retro_Plastic(DarkTire) }
+    // chrome hub cap on the outer face
+    sphere { <sx, 0.70, sz + 0.15 * (1 - 2 * div(k, 2))>, 0.20 Retro_Chrome(ChromeSil) }
+    #declare k = k + 1;
+  #end
+
+  // Spin the whole vehicle on the turntable (camera stays fixed).
+  rotate y * (clock * 360)
+}
+
+// Fixed 3/4 hero camera — front-right, slightly raised, so the spin reads.
+Retro_Camera(<5.4, 3.0, -5.6>, <0, 1.15, 0>)

--- a/scenes/deep_space.pov
+++ b/scenes/deep_space.pov
@@ -1,0 +1,96 @@
+// deep_space.pov — "Probe at the Amber Giant"
+// The Voyager-reference frame: a huge glowing amber planet hanging in a
+// near-black sky with a faint colored horizon glow, a thin tilted ring, a
+// scatter of stars, and a little chrome-and-plastic space probe (dish + body +
+// antenna) drifting in a slow orbit. The sun sits toward the camera so the
+// probe catches a bright rim even against the dark sky. Orbit camera.
+
+#include "retro90s.inc"
+
+// Deep-space sky: near-black overhead fading to a faint amber horizon glow that
+// echoes the planet — keeps the frame from going flat black.
+Retro_Sky_Gradient(
+  rgb <0.01, 0.01, 0.04>,    // top: near-black space
+  rgb <0.20, 0.09, 0.03>)    // horizon: dim amber wash
+
+// Key light placed toward the camera side so the chrome/plastic probe gets a
+// bright rim even though the sky is dark (chrome reads dark in space — the rim
+// is what sells it).
+Retro_Sun(<0.35, 0.25, 0.9>, rgb <1.0, 0.9, 0.72>)
+
+// --- starfield: a scatter of tiny emissive spheres flung out on a big shell.
+//     Deterministic pseudo-random placement so it renders the same every frame. -
+#declare StarTex = texture {
+  pigment { color rgb <1, 1, 1> }
+  finish { ambient 1.0 diffuse 0 }   // self-lit pin-pricks
+}
+#declare s = 0;
+#while (s < 140)
+  #declare sa = mod(s * 47, 360);
+  #declare sb = mod(s * 89, 180) - 90;
+  #declare sr = 95 + mod(s * 13, 40);
+  #declare sx = sr * cos(radians(sb)) * cos(radians(sa));
+  #declare sy = sr * sin(radians(sb));
+  #declare sz = sr * cos(radians(sb)) * sin(radians(sa));
+  sphere { <sx, sy, sz>, 0.30 + mod(s, 3) * 0.14 texture { StarTex } }
+  #declare s = s + 1;
+#end
+
+// --- the amber giant: a big glowing planet. High ambient makes it read as
+//     self-lit; a banded turbulent pigment gives it a gas-giant surface. -------
+sphere {
+  <-24, 5, -15>, 13
+  pigment {
+    gradient y
+    turbulence 0.35 octaves 4 lambda 2.2
+    color_map {
+      [0.0 color rgb <0.85, 0.42, 0.10>]
+      [0.4 color rgb <1.00, 0.68, 0.28>]
+      [0.6 color rgb <0.78, 0.34, 0.08>]
+      [1.0 color rgb <1.00, 0.80, 0.42>]
+    }
+    scale <18, 9, 18>
+  }
+  finish { ambient 0.85 diffuse 0.35 phong 0.15 phong_size 8 }
+}
+
+// A faint tilted ring around the planet — thin torus, gently glowing.
+torus {
+  17, 0.5
+  pigment { color rgbf <0.95, 0.72, 0.4, 0.45> }
+  finish { ambient 0.6 diffuse 0.25 }
+  scale <1, 0.12, 1>
+  rotate <22, 0, -14>
+  translate <-24, 5, -15>
+}
+
+// --- the space probe: dish + body + antenna, built from primitives and wrapped
+//     in a union so it drifts as one. Kept near the origin for the orbit frame. -
+union {
+  // main body: a stubby chrome octagonal bus (short cylinder)
+  cylinder { <0, 0, 0>, <0, 1.1, 0>, 0.55 Retro_Chrome(rgb <0.86, 0.9, 1.0>) }
+  // gold-foil cap plate (era loved gold spacecraft foil)
+  cylinder { <0, 1.1, 0>, <0, 1.24, 0>, 0.58 Retro_Chrome(rgb <1.0, 0.82, 0.35>) }
+  // high-gain dish: a shallow open cone facing forward
+  cone { <0, 0.55, 0>, 0.0, <0, 0.55, 1.7>, 1.25
+    open Retro_Chrome(rgb <0.92, 0.94, 1.0>) }
+  // dish feed on a little rod at the focus
+  cylinder { <0, 0.55, 1.7>, <0, 0.55, 0.9>, 0.05 Retro_Plastic(rgb <0.9, 0.9, 0.9>) }
+  sphere { <0, 0.55, 0.9>, 0.1 Retro_Plastic(rgb <1.0, 0.25, 0.2>) }
+  // long whip antenna out the back with a bright plastic tip
+  cylinder { <0, 0.55, 0>, <-0.2, 0.55, -2.4>, 0.04 Retro_Chrome(rgb <0.8, 0.85, 0.95>) }
+  sphere { <-0.2, 0.55, -2.4>, 0.09 Retro_Plastic(rgb <0.2, 0.9, 1.0>) }
+  // a boxy instrument pod slung under the bus
+  box { <-0.35, -0.45, -0.3>, <0.35, 0.0, 0.3> Retro_Plastic(rgb <0.9, 0.85, 0.2>) }
+  // two stubby RTG booms out the sides, plastic
+  cylinder { <0.55, 0.55, 0>, <1.5, 0.75, 0>, 0.07 Retro_Plastic(rgb <0.75, 0.78, 0.8>) }
+  cylinder { <-0.55, 0.55, 0>, <-1.5, 0.35, 0>, 0.07 Retro_Plastic(rgb <0.75, 0.78, 0.8>) }
+
+  // give it a jaunty fixed tilt, then let it slowly tumble/drift with the clock
+  rotate <18, 0, 12>
+  rotate y * (clock * 220)
+  translate <0, 1.0, 0>
+}
+
+// Slow orbit around the probe, with the amber giant swinging through frame.
+Retro_Orbit_Camera(11, 3.4, <0, 1.0, 0>)

--- a/scenes/desert_dusk.pov
+++ b/scenes/desert_dusk.pov
@@ -1,0 +1,90 @@
+// desert_dusk.pov — "Mesa Mirage at Sundown"
+// The signature Beyond-the-Mind's-Eye desert shot: a vivid violet-to-orange
+// gradient sky, a dark ring of mesa silhouettes on the far horizon, a low warm
+// sun, and a little cluster of mirror-chrome and colored-glass forms sitting on
+// the dark sand near the origin — so every chrome face catches the sunset.
+// A slow chrome-and-glass hero obelisk turns as the camera orbits. Orbit camera.
+
+#include "retro90s.inc"
+#include "beyond90s.inc"
+
+// Vivid three-stop dusk — the signature Beyond-the-Mind's-Eye sunset: electric
+// violet overhead, a hot magenta-orange band, and a yellow horizon glow that the
+// chrome and the sand both drink in.
+Beyond_Sunset_Sky(
+  rgb <0.16, 0.10, 0.46>,    // top: deep twilight violet
+  rgb <1.00, 0.30, 0.42>,    // band: hot magenta-orange
+  rgb <1.00, 0.80, 0.34>)    // glow: yellow horizon
+
+// Low, warm key light raking in near the horizon for long desert shadows and
+// hard mirror highlights on the chrome.
+Retro_Sun(<-0.75, 0.22, -0.55>, rgb <1.0, 0.74, 0.44>)
+
+// --- the desert floor: a dark, faintly polished sand plane. Not a grid — the
+//     chrome should mirror pure sunset sky and dark ground, the way the
+//     "creature crossing the mesa" reference frame reads. -----------------------
+plane {
+  y, 0
+  pigment { color rgb <0.14, 0.07, 0.06> }   // dark dusk-shadowed sand
+  finish {
+    ambient 0.18 diffuse 0.5
+    reflection { 0.18 }
+    phong 0.2 phong_size 40
+  }
+}
+
+// --- a ring of dark mesa/butte silhouettes set way back on the far ground.
+//     Varying heights + widths give the ragged Monument-Valley skyline. They sit
+//     far enough out (radius ~60) that the orbit camera always frames a horizon
+//     line of them behind the hero. --------------------------------------------
+#declare MesaTex = texture {
+  pigment { color rgb <0.05, 0.03, 0.05> }   // near-black, just catching rim light
+  finish { ambient 0.14 diffuse 0.35 }
+}
+
+#declare mh = array[9] { 6.5, 11.0, 4.0, 9.0, 5.5, 13.0, 7.5, 3.5, 10.0 }
+#declare mw = array[9] { 5.0,  4.0, 6.5, 3.2, 7.0,  4.5, 3.0, 5.5,  4.2 }
+
+#declare i = 0;
+#while (i < 9)
+  #declare mang = i * 40 + 12;
+  #declare mrad = 58 + mod(i, 3) * 7;
+  #declare mx = mrad * cos(radians(mang));
+  #declare mz = mrad * sin(radians(mang));
+  box {
+    <-mw[i], 0, -mw[i] * 0.8>, <mw[i], mh[i], mw[i] * 0.8>
+    texture { MesaTex }
+    translate <mx, 0, mz>
+  }
+  #declare i = i + 1;
+#end
+
+// --- the hero cluster, kept near the origin so the orbit camera holds it. -----
+
+// A slow-turning obelisk: a chrome column crowned with a floating glass gem and
+// flanked by a chrome sphere, all wrapped so the whole form rotates with clock.
+union {
+  // tapered chrome column (two stacked cones read as a polished monolith)
+  cone { <0, 0, 0>, 1.1, <0, 3.4, 0>, 0.55 Retro_Chrome(rgb <0.86, 0.90, 1.0>) }
+  cone { <0, 3.4, 0>, 0.55, <0, 4.2, 0>, 0.0 Retro_Chrome(rgb <1.0, 0.9, 0.78>) }
+  // amber glass gem hovering above the tip, catching the sun through it
+  sphere { <0, 5.0, 0>, 0.7 Retro_Glass(rgb <1.0, 0.62, 0.18>) }
+  // a chrome ring around the column for reflective interest
+  torus { 1.5, 0.16 Retro_Chrome(rgb <0.8, 0.85, 0.95>) translate y*1.6 }
+  rotate y * (clock * 180)
+}
+
+// Big mirror-chrome sphere resting on the sand beside the obelisk.
+sphere { <3.6, 1.6, 1.4>, 1.6 Retro_Chrome(rgb <0.9, 0.93, 1.0>) }
+
+// Emerald refractive glass sphere — a cool complement to the warm sky.
+sphere { <-3.2, 1.2, 2.0>, 1.2 Retro_Glass(rgb <0.18, 0.95, 0.55>) }
+
+// Sapphire glass teardrop, small and bright, near the front.
+sphere { <-1.6, 0.7, -2.4>, 0.7 Retro_Glass(rgb <0.28, 0.5, 1.0>) }
+
+// A short chrome pylon for a long vertical reflection streak.
+cylinder { <4.4, 0, -2.6>, <4.4, 3.0, -2.6>, 0.3 Retro_Chrome(rgb <0.82, 0.86, 0.96>) }
+
+// Slow orbit, pulled back and raised so the mesa horizon and the sunset both read.
+Retro_Orbit_Camera(16, 3.6, <0, 2.4, 0>)

--- a/scenes/elyan_dream.pov
+++ b/scenes/elyan_dream.pov
@@ -1,0 +1,46 @@
+// elyan_dream.pov — "Chrome Cathedral at Dusk"
+// The quintessential mid-90s fever dream: mirror chrome, refractive glass, a
+// glowing ReBoot grid stretching to a fractal horizon under a hot sunset sky.
+// Hand-authored for the Elyan Labs vintage-CGI channel. Orbit camera.
+
+#include "retro90s.inc"
+
+// Vivid dusk — bright enough that the chrome has a real sunset to mirror.
+Retro_Sky_Gradient(
+  rgb <0.22, 0.30, 1.00>,    // top: electric cobalt
+  rgb <1.00, 0.66, 0.32>)    // horizon: hot orange sunset
+
+// Strong warm key light so the chrome throws hard mirror highlights.
+Retro_Sun(<-0.6, 0.55, -0.45>, rgb <1.0, 0.92, 0.74>)
+
+// The glowing cyan ReBoot grid — the floor of the dream, stretching to the
+// sunset horizon. No terrain: the chrome mirrors pure sky and grid, the way the
+// iconic mid-90s "infinite grid" renders did.
+Retro_Grid_Floor(rgb <0.20, 0.95, 1.0>, rgb <0.02, 0.03, 0.08>, 1.5)
+
+// --- the hero cluster, centered near the origin so it stays framed ----------
+
+// Big mirror-chrome sphere: the altar of the cathedral.
+sphere { <0, 2.3, 5.0>, 2.3 Retro_Chrome(rgb <0.86, 0.90, 1.0>) }
+
+// A second, smaller chrome sphere nesting against it.
+sphere { <2.6, 1.1, 3.6>, 1.1 Retro_Chrome(rgb <1.0, 0.92, 0.82>) }
+
+// Emerald refractive glass sphere catching the sunset through it.
+sphere { <-3.4, 1.5, 6.6>, 1.5 Retro_Glass(rgb <0.15, 0.95, 0.60>) }
+
+// Sapphire glass teardrop, small and bright.
+sphere { <-1.2, 0.75, 2.4>, 0.75 Retro_Glass(rgb <0.25, 0.45, 1.0>) }
+
+// The hard-hotspot plastic torus — pure 1994 demo-reel energy.
+torus { 1.7, 0.42
+  Retro_Plastic(rgb <1.0, 0.15, 0.35>)
+  rotate x*68 rotate y*20 translate <3.6, 1.5, 6.8>
+}
+
+// A tall thin chrome pillar for vertical interest and long reflections.
+cylinder { <-5.0, 0, 8.0>, <-5.0, 5.2, 8.0>, 0.35
+  Retro_Chrome(rgb <0.80, 0.85, 0.95>) }
+
+// Slowly orbit the whole altar, pulled back so the composition breathes.
+Retro_Orbit_Camera(15, 5.0, <0, 2.0, 5.0>)

--- a/scenes/tinkertoy.pov
+++ b/scenes/tinkertoy.pov
@@ -1,0 +1,63 @@
+// tinkertoy.pov — "Tinker Toy Windmill"
+// An early-Pixar tabletop: warm key light, soft checker floor, glossy primary
+// plastic. A classic Tinker Toy build -- natural-wood spool hubs and bright
+// colored rods -- assembled into a windmill whose sails slowly turn. The look
+// nods to Luxo Jr. / Tin Toy (1986-88): simple geometric toys with warmth.
+
+#include "retro90s.inc"
+
+// Soft warm sky — a lit room, not an outdoor sunset.
+Retro_Sky_Gradient(
+  rgb <0.52, 0.64, 0.88>,    // top: gentle sky blue
+  rgb <1.00, 0.88, 0.66>)    // horizon: warm cream
+
+// High, warm key light for soft early-CGI shadows.
+Retro_Sun(<-0.45, 0.85, -0.35>, rgb <1.00, 0.96, 0.86>)
+
+// The tabletop: a warm cream-and-walnut checkerboard, lightly polished.
+Retro_Checker_Floor(rgb <0.93, 0.90, 0.83>, rgb <0.52, 0.31, 0.19>, 0.14)
+
+// --- Tinker Toy palette -----------------------------------------------------
+#declare Wood = rgb <0.82, 0.58, 0.32>;   // natural birch spool
+#declare Rod  = array[6] {
+  rgb <0.88, 0.16, 0.16>,   // red
+  rgb <0.16, 0.36, 0.88>,   // blue
+  rgb <0.16, 0.72, 0.28>,   // green
+  rgb <0.97, 0.82, 0.16>,   // yellow
+  rgb <0.97, 0.52, 0.12>,   // orange
+  rgb <0.62, 0.24, 0.72>    // violet
+}
+
+// --- the stand: base spool + upright mast + hub spool -----------------------
+cylinder { <0, 0.00, 0>, <0, 0.30, 0>, 0.60 Retro_Plastic(Wood) }   // base spool
+cylinder { <0, 0.30, 0>, <0, 2.30, 0>, 0.09 Retro_Plastic(Rod[1]) } // blue mast
+
+#declare HubY = 2.30;
+cylinder { <0, HubY, 0>, <0, HubY + 0.28, 0>, 0.52 Retro_Plastic(Wood) }  // hub spool
+
+// --- the sails: six colored rods radiating from the hub, each capped by a
+//     small wood spool. Wrapped in a union so the whole wheel slowly turns. ---
+union {
+  #declare i = 0;
+  #while (i < 6)
+    #declare ang = i * 60;
+    #declare ex = 1.85 * cos(radians(ang));
+    #declare ez = 1.85 * sin(radians(ang));
+    cylinder { <0, HubY + 0.14, 0>, <ex, HubY + 0.14, ez>, 0.07 Retro_Plastic(Rod[i]) }
+    cylinder { <ex, HubY, ez>, <ex, HubY + 0.28, ez>, 0.30 Retro_Plastic(Wood) }
+    // a short bright stub off each end spool, for that busy Tinker Toy silhouette
+    cylinder { <ex, HubY + 0.14, ez>,
+               <ex * 1.28, HubY + 0.55, ez * 1.28>, 0.06 Retro_Plastic(Rod[mod(i + 2, 6)]) }
+    #declare i = i + 1;
+  #end
+  rotate y * (clock * 300)     // the windmill turns as the camera orbits
+}
+
+// A couple of loose Tinker Toy pieces resting on the table, for scale + charm.
+cylinder { <2.6, 0.0, -1.4>, <2.6, 0.22, -1.4>, 0.42 Retro_Plastic(Wood) }
+cylinder { <2.6, 0.11, -1.4>, <3.9, 0.11, -0.7>, 0.06 Retro_Plastic(Rod[0]) }
+sphere    { <-2.7, 0.35, 1.2>, 0.35 Retro_Plastic(Rod[3]) }
+
+// Tabletop hero camera, raised so the checkerboard recedes to the horizon --
+// the classic early-Pixar three-quarter tabletop view. Orbits the windmill.
+Retro_Orbit_Camera(7.2, 3.9, <0, 1.7, 0>)


### PR DESCRIPTION
## What

Adds `lib/beyond90s.inc`, a second macro library for the early-90s CGI compilation look ("Beyond the Mind's Eye" era) that `retro90s.inc` did not cover, plus six demo scenes that compose the two libraries. This is what let the studio hit that vibe for a batch of videos on the channel.

### New macros (`lib/beyond90s.inc`)
- **`Beyond_Sunset_Sky(c_top, c_band, c_glow)`** — the signature three-stop sky: violet zenith, hot magenta-orange band, yellow horizon glow. Also warms below the horizon so chrome and floors reflect the sunset (the "chrome needs a bright sky to mirror" rule).
- **`Beyond_Mesa_Ring(butte_color, butte_count, dist, height)`** — a deterministic ring of dark stepped mesa/butte silhouettes on the horizon.
- **`Beyond_Gold(tint)`** — warm metallic gold chrome texture.
- **`Beyond_Starfield(star_density, star_color)`** — emissive star dots on the sky.
- **`Beyond_Planet(p_radius, surface_color, glow_color)`** — a glowing banded planet with a view-independent atmosphere rim, for space scenes.
- **`Beyond_Plinth(plinth_size, top_color)`** — a product-viz turntable plinth.

Gotcha documented in the file: POV-Ray reserves `count`/`density`/`radius`/`size` as keywords, so the parameters use `butte_count`/`star_density`/`p_radius`/`plinth_size`.

### Demo scenes (`scenes/`)
`elyan_dream` (chrome+glass on the grid), `tinkertoy` (early-Pixar windmill on checker), `desert_dusk` (mesa sunset), `deep_space` (probe + gas giant), `concept_turntable` (spinning concept car on a plinth), `beyond_demo` (sunset + starfield + planet + mesas + gold idol on a plinth — exercises all six new macros).

## Verification
Every scene renders in POV-Ray (exit 0, no parse errors), and each was eyeballed and art-directed for the final look. Five of these were rendered to video and published to the channel; `beyond_demo` (as "Sunset Relic") is queued behind the per-bot upload rate limit.

Follow-up (not in this PR): teach `ai_scene.py`'s system prompt about the new `Beyond_*` macros so the LLM scene generator can reach for them.