### PR TITLE
fix(validate): the pre-render check rejects 14 of the repo's own scenes, and misses the three errors POV-Ray dies on

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ export RETRO_LLM_MODEL="qwen2.5-7b-instruct-q4_k_m-00001-of-00002.gguf"
 
 ```
 ai_scene.py        prompt -> POV-Ray scene (LLM, OpenAI-compatible backend)
+fd_validate.py     macro-contract check run before the raytrace (ai_scene.py
+                   calls it; `./fd_validate.py scene.pov` to check by hand)
 render.sh          single-frame still render (CPU)
 animate.sh         frame sequence -> mp4 (+ optional CRT/VHS post)
 crt_post.sh        standalone VHS/CRT degrade pass

--- a/fd_validate.py
+++ b/fd_validate.py
@@ -11,7 +11,10 @@ against the macro contract in `lib/*.inc` first, so ai_scene.py can reject or
 feed the exact errors back to the model instead of burning a render.
 
 The known-macro set and each macro's arity are harvested from `lib/*.inc` at
-run time, so this never drifts from the library.
+run time, so this never drifts from the library. Macros the scene defines for
+itself are harvested from the scene the same way: defining a local helper is a
+style warning (scenes should compose), not a parse error, so calls to it are
+checked against its own signature instead of being reported as invented.
 
     ./fd_validate.py scene.pov            # exit 0 = ok, 1 = errors
     validate_scene(source, lib_dir)       # -> {ok, errors, warnings, macros_used}
@@ -23,17 +26,108 @@ import sys
 HERE = os.path.dirname(os.path.abspath(__file__))
 DEFAULT_LIB = os.path.join(HERE, "lib")
 
-_OPEN = {"(": ")", "[": "]", "{": "}", "<": ">"}
+_OPEN = {"(": ")", "[": "]", "{": "}"}
 _CLOSE = {v: k for k, v in _OPEN.items()}
+
+# `#macro Name(a, b)` — the parameter list may span lines (skeleton.inc does).
+_MACRO_DEF = re.compile(r"#macro\s+([A-Za-z_]\w*)\s*\(([^)]*)\)")
+_DECLARE = re.compile(r"#(declare|local)\s+([A-Za-z_]\w*)")
+
+# POV-Ray keywords cannot be re-declared: `#macro Orb(x, y, r)` or
+# `#local radius = 2;` is a fatal parse error ("Expected 'undeclared
+# identifier', radius found instead"), not a shadowed name. Every word below
+# was verified against POV-Ray 3.7.0.10 by actually parsing a scene that uses
+# it as a macro parameter; the real keyword list is longer, so this catches the
+# names a scene author (or a 3B model) is likely to reach for, not all of them.
+_RESERVED = frozenset("""
+t u v x y z pi clock
+alpha ambient angle brightness color colour count density diffuse direction
+distance emission end filter finish floor frequency gamma green blue red
+interior inverse ior jitter location look_at material matrix max metallic min
+no normal off offset on orientation pattern phase pigment radius ratio
+reflection right rotate roughness scale seed size sky specular spacing
+strength target text texture thickness transmit translate true false turbulence
+type up val width wood yes
+""".split())
+
+# Object modifiers. Legal on an object, fatal inside a texture{} block
+# ("No matching } in 'texture', no_shadow found instead") — all verified.
+_OBJECT_ONLY = ("no_shadow", "no_image", "no_reflection", "double_illuminate",
+                "inverse", "hollow", "clipped_by", "bounded_by")
+
+
+def _scan(src: str, keep_strings: bool = False) -> str:
+    """One pass over the source honouring both comments and string literals.
+
+    Comments and strings must be recognised together, not in two independent
+    regex passes: `"art//grid.png"` is a string that merely looks like it holds
+    a comment, and stripping comments first would eat the closing quote, after
+    which the orphaned quote swallows an arbitrary span of the scene (every
+    macro call inside it silently unchecked, braces inside it uncounted).
+
+    Comments collapse to a space. Strings collapse to `""` unless keep_strings.
+    An unterminated string stops at the end of its line — POV-Ray strings do
+    not span lines, so a stray quote costs one line, not the rest of the file.
+    """
+    out, i, n = [], 0, len(src)
+    while i < n:
+        c = src[i]
+        if c == "/" and i + 1 < n and src[i + 1] == "*":
+            end = src.find("*/", i + 2)
+            i = n if end == -1 else end + 2
+            out.append(" ")
+        elif c == "/" and i + 1 < n and src[i + 1] == "/":
+            end = src.find("\n", i)
+            i = n if end == -1 else end          # keep the newline itself
+            out.append(" ")
+        elif c == '"':
+            j = i + 1
+            while j < n and src[j] not in ('"', "\n"):
+                j += 2 if src[j] == "\\" else 1
+            closed = j < n and src[j] == '"'
+            j = j + 1 if closed else j
+            out.append(src[i:j] if keep_strings else '""')
+            i = j
+        else:
+            out.append(c)
+            i += 1
+    return "".join(out)
 
 
 def strip_noise(src: str) -> str:
     """Remove // and /* */ comments and "double-quoted strings" so brace/paren
     scanning and macro detection never trip over text inside them."""
-    src = re.sub(r"/\*.*?\*/", " ", src, flags=re.DOTALL)
-    src = re.sub(r"//[^\n]*", " ", src)
-    src = re.sub(r'"(?:[^"\\]|\\.)*"', '""', src)
-    return src
+    return _scan(src)
+
+
+def strip_comments(src: str) -> str:
+    """Remove comments but keep string literals (for #include detection)."""
+    return _scan(src, keep_strings=True)
+
+
+def _macro_defs(text: str) -> dict:
+    """Return {macro_name: (param_names, position)} for every #macro in text."""
+    defs = {}
+    for m in _MACRO_DEF.finditer(text):
+        name, args = m.group(1), m.group(2).strip()
+        params = tuple(a.strip() for a in args.split(",")) if args else ()
+        defs[name] = (params, m.start(1))
+    return defs
+
+
+def _blocks(src: str, keyword: str):
+    """Yield the body text of every `keyword { ... }` block, braces matched."""
+    for m in re.finditer(r"\b" + keyword + r"\s*\{", src):
+        i, depth, j, n = m.end() - 1, 0, m.end() - 1, len(src)
+        while j < n:
+            if src[j] == "{":
+                depth += 1
+            elif src[j] == "}":
+                depth -= 1
+                if depth == 0:
+                    yield src[i + 1:j]
+                    break
+            j += 1
 
 
 def harvest_macros(lib_dir: str) -> dict:
@@ -46,36 +140,52 @@ def harvest_macros(lib_dir: str) -> dict:
             continue
         text = strip_noise(open(os.path.join(lib_dir, fn), encoding="utf-8",
                                  errors="replace").read())
-        for m in re.finditer(r"#macro\s+([A-Za-z_]\w*)\s*\(([^)]*)\)", text):
-            name, args = m.group(1), m.group(2).strip()
-            macros[name] = 0 if args == "" else args.count(",") + 1
+        for name, (params, _pos) in _macro_defs(text).items():
+            macros[name] = len(params)
     return macros
 
 
 def _split_top_level_args(inner: str):
     """Split a macro call's argument text on TOP-LEVEL commas only — commas
-    inside <vectors>, nested (calls), {blocks} or [arrays] do not separate args."""
-    args, depth, cur = [], 0, []
-    for ch in inner:
-        if ch in _OPEN:
-            depth += 1
-        elif ch in _CLOSE:
-            depth = max(0, depth - 1)
-        if ch == "," and depth == 0:
-            args.append("".join(cur))
-            cur = []
-        else:
-            cur.append(ch)
-    tail = "".join(cur).strip()
-    if tail or args:
-        args.append(tail)
-    return [a.strip() for a in args]
+    inside <vectors>, nested (calls), {blocks} or [arrays] do not separate args.
+
+    POV-Ray spells comparisons with the same characters it uses for vectors, so
+    `<`/`>` get their own counter: a `>` closes nothing unless a `<` is actually
+    open, which keeps `select(clock>0.5, a, b)` from closing the `(` around it.
+    If a `<` is still open at the end it was a less-than, so the text is split
+    again with angle brackets treated as ordinary characters."""
+    def split(use_angles):
+        args, depth, angle, cur = [], 0, 0, []
+        for ch in inner:
+            if ch in _OPEN:
+                depth += 1
+            elif ch in _CLOSE:
+                depth = max(0, depth - 1)
+            elif use_angles and ch == "<":
+                angle += 1
+            elif use_angles and ch == ">" and angle:
+                angle -= 1
+            if ch == "," and depth == 0 and angle == 0:
+                args.append("".join(cur))
+                cur = []
+            else:
+                cur.append(ch)
+        tail = "".join(cur).strip()
+        if tail or args:
+            args.append(tail)
+        return [a.strip() for a in args], angle
+
+    args, angle = split(True)
+    if angle:
+        args, _ = split(False)
+    return args
 
 
 def _find_calls(src: str):
-    """Yield (name, arg_text, ok_balanced) for every `Identifier( ... )` whose
-    name starts with an uppercase letter (library macros are Capitalized; POV
-    built-ins are lowercase). Uses balanced-paren matching to grab the arg text."""
+    """Yield (name, arg_text, ok_balanced, position) for every `Identifier( ... )`
+    whose name starts with an uppercase letter (library macros are Capitalized;
+    POV built-ins are lowercase). Uses balanced-paren matching to grab the arg
+    text."""
     for m in re.finditer(r"\b([A-Z]\w*)\s*\(", src):
         name = m.group(1)
         i = m.end() - 1  # at the '('
@@ -88,11 +198,11 @@ def _find_calls(src: str):
             elif c == ")":
                 depth -= 1
                 if depth == 0:
-                    yield name, src[i + 1:j], True
+                    yield name, src[i + 1:j], True, m.start(1)
                     break
             j += 1
         else:
-            yield name, src[i + 1:], False
+            yield name, src[i + 1:], False, m.start(1)
 
 
 def validate_scene(source: str, lib_dir: str = DEFAULT_LIB) -> dict:
@@ -100,16 +210,33 @@ def validate_scene(source: str, lib_dir: str = DEFAULT_LIB) -> dict:
     errors, warnings, used = [], [], []
     clean = strip_noise(source)
 
-    # 1. must pull in the library
-    if '#include "retro90s.inc"' not in source and "#include \"retro90s.inc\"" not in source:
-        errors.append('missing `#include "retro90s.inc"` (must be the first line)')
+    # 1. must pull in the library — and a commented-out #include does not count
+    if '#include "retro90s.inc"' not in strip_comments(source):
+        errors.append('missing `#include "retro90s.inc"` (the library must be '
+                      'pulled in before any Retro_* macro)')
 
-    # 2. the scene must not redefine library macros
-    for m in re.finditer(r"#macro\s+([A-Za-z_]\w*)", clean):
-        if m.group(1) in macros:
-            errors.append(f"redefines library macro `{m.group(1)}` (forbidden)")
+    # 2. the scene must not redefine library macros; its own helpers are legal
+    #    (a style warning) and become part of the contract for step 4
+    local, def_sites = {}, set()
+    for name, (params, pos) in _macro_defs(clean).items():
+        def_sites.add(pos)
+        if name in macros:
+            errors.append(f"redefines library macro `{name}` (forbidden)")
         else:
-            warnings.append(f"defines its own macro `{m.group(1)}` (scenes should compose, not define)")
+            warnings.append(f"defines its own macro `{name}` (scenes should compose, not define)")
+            local[name] = len(params)
+        for p in params:
+            if p in _RESERVED:
+                errors.append(f"`{name}` names a parameter `{p}`, which is a POV-Ray "
+                              f"keyword — POV-Ray cannot declare it and refuses the scene")
+    known = dict(macros)
+    known.update(local)
+
+    # 2b. same trap for #declare/#local names
+    for m in _DECLARE.finditer(clean):
+        if m.group(2) in _RESERVED:
+            errors.append(f"`#{m.group(1)} {m.group(2)}` — `{m.group(2)}` is a POV-Ray "
+                          f"keyword and cannot be declared")
 
     # 3. balanced braces/parens overall (catch truncated output)
     for op, name in ((("{", "}"), "braces"), (("(", ")"), "parens")):
@@ -118,22 +245,44 @@ def validate_scene(source: str, lib_dir: str = DEFAULT_LIB) -> dict:
 
     # 4. every Capitalized(...) call must be a known macro with the right arity
     cams = 0
-    for name, arg_text, balanced in _find_calls(clean):
+    for name, arg_text, balanced, pos in _find_calls(clean):
+        if pos in def_sites:      # the #macro line itself is a definition
+            continue
         if not balanced:
             errors.append(f"`{name}(` is never closed (truncated scene?)")
             continue
-        if name not in macros:
-            errors.append(f"unknown macro `{name}` — not defined in lib/*.inc")
+        if name not in known:
+            errors.append(f"unknown macro `{name}` — not defined in lib/*.inc "
+                          f"and not defined in this scene")
             continue
         used.append(name)
         if name in ("Retro_Camera", "Retro_Orbit_Camera"):
             cams += 1
         got = len(_split_top_level_args(arg_text)) if arg_text.strip() else 0
-        want = macros[name]
+        want = known[name]
         if got != want:
-            errors.append(f"`{name}` takes {want} arg(s), got {got}: ({arg_text.strip()[:60]})")
+            where = "" if name in macros else " (defined in this scene)"
+            errors.append(f"`{name}`{where} takes {want} arg(s), got {got}: ({arg_text.strip()[:60]})")
 
-    # 5. exactly one hero camera is expected
+    # 5. texture{} blocks: the material macros already ARE a texture, and object
+    #    modifiers belong on the object, not inside its texture
+    for body in _blocks(clean, "texture"):
+        m = re.match(r"\s*(Retro_(?:Chrome|Glass|Plastic))\s*\(", body)
+        if m:
+            errors.append(f"`{m.group(1)}(...)` is wrapped in `texture{{ }}` — the macro "
+                          f"already expands to a full texture block, so POV-Ray reports "
+                          f"`No matching }} in 'texture'`. Apply it directly in the object.")
+        for kw in _OBJECT_ONLY:
+            if re.search(r"\b" + kw + r"\b", body):
+                errors.append(f"`{kw}` is inside a `texture{{ }}` block — it is an object "
+                              f"modifier and POV-Ray stops there. Move it out to the object.")
+    for body in _blocks(clean, "material"):
+        m = re.match(r"\s*(Retro_(?:Chrome|Glass|Plastic))\s*\(", body)
+        if m:
+            errors.append(f"`{m.group(1)}(...)` is wrapped in `material{{ }}` — the macro "
+                          f"already expands to a full texture block")
+
+    # 6. exactly one hero camera is expected
     if cams == 0:
         warnings.append("no Retro_Camera / Retro_Orbit_Camera — POV will use a default view")
     elif cams > 1:

--- a/test_fd_validate.py
+++ b/test_fd_validate.py
@@ -1,10 +1,21 @@
-import sys; sys.path.insert(0, ".")
+import glob, os, sys; sys.path.insert(0, ".")
 from fd_validate import validate_scene
 LIB="lib"
 def has_err(src, needle):
     r=validate_scene(src, LIB)
     hit=any(needle in e for e in r["errors"])
     print(f"  [{'PASS' if hit else 'FAIL'}] catches '{needle}': errors={r['errors'][:2]}")
+    return hit
+
+def is_ok(src, label):
+    r=validate_scene(src, LIB)
+    print(f"  [{'PASS' if r['ok'] else 'FAIL'}] {label}: errors={r['errors'][:2]}")
+    return r["ok"]
+
+def has_warn(src, needle, label):
+    r=validate_scene(src, LIB)
+    hit=any(needle in w for w in r["warnings"])
+    print(f"  [{'PASS' if hit else 'FAIL'}] {label}")
     return hit
 
 GOOD = '''#include "retro90s.inc"
@@ -34,6 +45,89 @@ nocam=validate_scene(GOOD.replace("Retro_Camera(<0,4,-10>, <0,1,4>)\n",""), LIB)
 cam_warn=any("no Retro_Camera" in w for w in nocam["warnings"])
 print(f"  [{'PASS' if (nocam['ok'] and cam_warn) else 'FAIL'}] no-camera is a warning not an error")
 fails += 0 if (nocam["ok"] and cam_warn) else 1
+
+
+# --- a scene may define its own helper macro (warning, not a parse error) ---
+LOCAL = GOOD.replace("sphere { <0,2,6>, 2 Retro_Chrome(rgb <0.8,0.9,1.0>) }", '''#macro Rock(cx, cy, r, tint)
+  sphere { <cx, cy, 6>, r Retro_Chrome(tint) }
+#end
+Rock(-2, 2, 1.2, rgb <0.7,0.5,0.4>)
+Rock( 2, 2, 0.8, rgb <0.5,0.6,0.8>)''')
+fails += 0 if is_ok(LOCAL, "scene-local macro is not an 'unknown macro'") else 1
+fails += 0 if has_warn(LOCAL, "defines its own macro `Rock`",
+                       "scene-local macro still warns 'should compose'") else 1
+# ...but the local macro's own signature is now enforced
+fails += 0 if has_err(LOCAL.replace("Rock(-2, 2, 1.2, rgb <0.7,0.5,0.4>)",
+                                    "Rock(-2, 2, 1.2)"), "`Rock` (defined in this scene) takes 4") else 1
+# ...and an invented macro is still caught in a scene that defines helpers
+fails += 0 if has_err(LOCAL.replace("Rock( 2, 2, 0.8, rgb <0.5,0.6,0.8>)",
+                                    "Retro_Water(<0,0,0>, 5)"), "unknown macro `Retro_Water`") else 1
+
+# --- a string that contains // must not blind the scanner ---
+# (stripping comments before strings ate the closing quote, and the orphaned
+#  quote then swallowed everything up to the next quote in the scene)
+SLASHES = GOOD.replace('Retro_Fractal_Terrain(14, 22, Retro_Terrain_Texture())',
+                       '#declare Grid = "art//grid.png"\nRetro_Water(<0,0,0>, 5)\n#declare Note = "hero"')
+fails += 0 if has_err(SLASHES, "unknown macro `Retro_Water`") else 1
+BRACE = GOOD.replace('Retro_Fractal_Terrain(14, 22, Retro_Terrain_Texture())',
+                     '#declare Grid = "art//grid.png"').replace(
+                     'sphere { <0,2,6>, 2 Retro_Chrome(rgb <0.8,0.9,1.0>) }',
+                     'sphere { <0,2,6>, 2\n  Retro_Chrome(rgb <0.8,0.9,1.0>)\n  #debug "placed\\n"\n}')
+fails += 0 if is_ok(BRACE, "string with // does not fake a brace imbalance") else 1
+# a commented-out include is not an include
+fails += 0 if has_err(GOOD.replace('#include "retro90s.inc"',
+                                   '// #include "retro90s.inc"'), "missing `#include") else 1
+
+# --- < and > are comparison operators too, not only vector brackets ---
+fails += 0 if is_ok(GOOD.replace("Retro_Checker_Floor", "Retro_Checker_Floor").replace(
+    'Retro_Fractal_Terrain(14, 22, Retro_Terrain_Texture())',
+    'Retro_Checker_Floor(rgb <0.9,0.9,0.95>, rgb <0.1,0.1,0.15>, select(clock>0.5, 0.2, 0.8))'),
+    "comparison inside a macro argument does not miscount args") else 1
+
+# --- POV-Ray-authored checks: a keyword cannot be a parameter or a #declare ---
+fails += 0 if has_err(GOOD.replace("sphere { <0,2,6>, 2 Retro_Chrome(rgb <0.8,0.9,1.0>) }",
+    "#macro Orb(x, y, radius)\n  sphere { <x, y, 6>, radius Retro_Chrome(rgb <1,1,1>) }\n#end\nOrb(0, 2, 2)"),
+    "names a parameter `x`") else 1
+fails += 0 if has_err(GOOD.replace("Retro_Sun(", "#declare size = 3;\nRetro_Sun("),
+                      "`#declare size`") else 1
+fails += 0 if is_ok(GOOD.replace("sphere { <0,2,6>, 2 Retro_Chrome(rgb <0.8,0.9,1.0>) }",
+    "#macro Orb(cx, cy, rad)\n  sphere { <cx, cy, 6>, rad Retro_Chrome(rgb <1,1,1>) }\n#end\nOrb(0, 2, 2)"),
+    "non-keyword parameter names are fine") else 1
+
+# --- the material macros already ARE a texture; modifiers belong on the object ---
+fails += 0 if has_err(GOOD.replace("sphere { <0,2,6>, 2 Retro_Chrome(rgb <0.8,0.9,1.0>) }",
+    "sphere { <0,2,6>, 2\n  texture { Retro_Chrome(rgb <0.8,0.9,1.0>) }\n}"),
+    "wrapped in `texture{ }`") else 1
+fails += 0 if has_err(GOOD.replace("sphere { <0,2,6>, 2 Retro_Chrome(rgb <0.8,0.9,1.0>) }",
+    "sphere { <0,2,6>, 2\n  texture { pigment { rgb <0.8,0.2,0.2> } finish { ambient 1 } no_shadow }\n}"),
+    "`no_shadow` is inside a `texture{ }` block") else 1
+fails += 0 if is_ok(GOOD.replace("sphere { <0,2,6>, 2 Retro_Chrome(rgb <0.8,0.9,1.0>) }",
+    "sphere { <0,2,6>, 2\n  texture { pigment { rgb <0.8,0.2,0.2> } finish { ambient 1 } }\n  no_shadow\n}"),
+    "no_shadow on the object (not in the texture) is fine") else 1
+
+# --- regression: the verdict on every shipped scene must match POV-Ray's own ---
+# Ground truth from rendering all 61 at 160x90 with POV-Ray 3.7.0.10: 57 parse,
+# 4 do not. Those 4 are the KNOWN_BAD below (the reason given is POV-Ray's own
+# first error), plus mainframe_residents.pov, which POV-Ray renders but which
+# breaks the project's own rule 2 by redefining the library macro Googly.
+KNOWN_BAD={
+  "scenes/templates/asteroid_field.pov":     "no_shadow/inverse inside texture{}",
+  "scenes/templates/bouncy_90s_demo.pov":    "#macro Orb(x, y, ...) — x/y are keywords",
+  "scenes/templates/chrome_text_logo.pov":   "#macro ChromeBlock(x, y, ...) — keywords",
+  "scenes/templates/glass_city_skyline.pov": "no_shadow inside texture{}",
+  "scenes/templates/mainframe_residents.pov":"redefines library macro Googly",
+}
+bad={}
+for f in sorted(glob.glob("scenes/*.pov")) + sorted(glob.glob("scenes/templates/*.pov")):
+    r=validate_scene(open(f, encoding="utf-8", errors="replace").read(), LIB)
+    if not r["ok"]:
+        bad[f]=r["errors"][:1]
+unexpected=[f for f in bad if f not in KNOWN_BAD]
+missed=[f for f in KNOWN_BAD if f not in bad]
+ok = not unexpected and not missed
+print(f"  [{'PASS' if ok else 'FAIL'}] shipped scenes: {len(bad)} invalid, expected "
+      f"{len(KNOWN_BAD)} (false rejects: {unexpected[:3]}, missed: {missed[:3]})")
+fails += 0 if ok else 1
 
 print(f"\n{'ALL VALIDATOR TESTS PASSED' if fails==0 else str(fails)+' TEST(S) FAILED'}")
 sys.exit(1 if fails else 0)


### PR DESCRIPTION
The pre-render validator added in #19 is meant to catch a bad scene before the raytrace burns time. Running it over the scenes this repo ships, it rejects **14 of 61** — and `ai_scene.py` gates the render on `vr["ok"]`, so those scenes never reach POV-Ray. Meanwhile the three failures that actually kill a render here go unnoticed.

I rendered all 61 shipped scenes with real POV-Ray 3.7.0.10 (`+W160 +H90`, `+L lib`) to get ground truth: **57 parse and render, 4 do not.** That is the yardstick used throughout below.

## 1. A scene that defines its own helper macro can never render

`validate_scene` harvests macros from `lib/*.inc` only. A `#macro` written in the scene is never added to the known set, so **every call to it** — and the `#macro` line itself — comes back `unknown macro`. Rule 2 in the same function says the opposite: defining one is a *warning*, "scenes should compose, not define". The warning is dead code; the error always fires alongside it.

`ai_scene.py` doesn't just report that, it re-asks the model with the errors and gives up:

```
$ ./ai_scene.py "chrome asteroids" --llm-url <stub returning a scene with #macro Rock(...)>
[ai] warn: defines its own macro `Rock` (scenes should compose, not define)
[ai] scene rejected before render:
  unknown macro `Rock` — not defined in lib/*.inc
  ... (3 LLM generations burned)
[ai] giving up: scene never passed validation          exit 1
```

with this PR the same scene is accepted on attempt 1, warning intact, exit 0. POV-Ray renders it fine (6.8 KB PNG) — scene-local macros are ordinary POV-Ray.

Rejected today, and `tron_lightcycle`, `game_cube`, `mainframe_city`, `sc_battlecruiser` among them render perfectly:

```
asteroid_field  base_to_war  bouncy_90s_demo  cavalry_charge  chrome_text_logo
game_cube  glass_city_skyline  grand_battle  mainframe_city  mainframe_residents
marching_army  sc_battlecruiser  sc_siege  tron_lightcycle
```

Fix: harvest the scene's own `#macro`s the same way as the library's, keep the compose warning, arity-check local macros too (`` `Rock` (defined in this scene) takes 4 arg(s), got 3 ``), and skip the definition line when scanning for calls.

## 2. A string containing `//` blinds the checker

`strip_noise` removed comments first and strings second. `"art//grid.png"` therefore lost its closing quote, and the orphaned quote then paired with the *next* quote in the scene — swallowing everything between them:

```python
strip_noise('#declare S = "http://x.ai/y"; box{<0,0,0>,<1,1,1>}')
main:  '#declare S = "http: '            # the box is gone
```

Two consequences, both reproduced in the tests: an invented macro sitting in that span is never reported (`ok: true` on a scene that cannot render), and a `{` inside the span with its `}` outside fabricates `unbalanced braces: 0 { vs 1 }`. Fix: one scanner that understands comments and strings together; an unterminated string stops at end of line, since POV-Ray strings don't span lines.

## 3. `>` closed a paren it never opened

`<` and `>` shared the bracket counter with `(`/`[`/`{`, but POV-Ray spells comparisons with the same characters:

```
Retro_Checker_Floor(rgb <0.9,0.9,0.95>, rgb <0.1,0.1,0.15>, select(clock>0.5, 0.2, 0.8))
main:  `Retro_Checker_Floor` takes 3 arg(s), got 5     # the > in clock>0.5 closed select(
```

Angle brackets get their own counter now, a `>` closes nothing unless a `<` is open, and if a `<` is still open at the end (it was a less-than) the text is split again ignoring angles. Vector-safety, which the existing test pins, is unchanged.

## 4. A commented-out `#include` counted as an include

The check ran on the raw source, so `// #include "retro90s.inc"` satisfied the one hard requirement — the scene then dies in POV-Ray with `Cannot find macro Retro_Sun`. It now runs on comment-stripped text (strings kept). The old message also claimed "must be the first line", which was never checked and isn't true of the shipped scenes — reworded rather than enforced.

## What it was missing: the three things POV-Ray actually refuses

All four scenes POV-Ray rejects fail for reasons the validator had no rule for. Each verified with a minimal scene, not inferred:

**A POV-Ray keyword as a macro parameter or `#declare` name.**

```
#macro Orb(x, y, radius)  ->  Parse Error: Expected 'identifier or expression.', vector function 'x' found instead
#local radius = 2;        ->  Parse Error: Expected 'undeclared identifier', radius found instead
```

This is not shadowing, it is fatal, and the trap is wide: `radius`, `size`, `angle`, `color`, `scale`, `distance`, `offset`, `target`, `count`, `seed`, `strength`, `width`, `min`, `max`, `type`, `alpha`… all reserved, all natural names for a 3B model to pick — and two shipped templates already fall in (`Orb(x, y, ...)`, `ChromeBlock(x, y, ...)`). I probed 187 plausible parameter names against POV-Ray and shipped the 77 that fail; every one was parse-tested **both** as a macro parameter and as a `#declare` name, so there are no false positives in the list (it is deliberately not exhaustive — being on it is proven, being off it proves nothing).

**An object modifier inside `texture { }`.** `no_shadow`, `no_image`, `no_reflection`, `double_illuminate`, `inverse`, `hollow`, `clipped_by`, `bounded_by` — each gives `No matching } in 'texture', <kw> found instead` (all eight verified; moving it out to the object renders). `asteroid_field.pov` and `glass_city_skyline.pov` die here.

**`Retro_Chrome/Glass/Plastic` wrapped in `texture { }`** — the system prompt calls this "the #1 cause of errors", and `sanitize()` tries to un-nest it, but its regex only matches the form where the block contains *nothing else*, so the common multi-line form survives to POV-Ray:

```
sphere { <0,2,6>, 2 texture { Retro_Chrome(rgb <0.85,0.88,0.95>) } }
  ->  lib/retro90s.inc line 80: Parse Error: No matching } in 'texture'
same scene, unwrapped -> renders
```

## Result

| | main | this PR |
|---|---|---|
| shipped scenes rejected | 14 of 61 | 5 of 61 |
| of those, scenes POV-Ray renders fine | 10 | 1 |
| scenes POV-Ray refuses, and validator catches | 0 of 4 | **4 of 4**, naming POV-Ray's own reason |
| validator tests | 8 | 23 |

The verdict now agrees with POV-Ray on 60 of 61. The one difference is `mainframe_residents.pov`: it renders, but it redefines the library macro `Googly` (`lib/retro90s_characters.inc:6`), which rule 2 forbids — a project-policy call, so I left it flagged rather than "fixing" the rule or the scene.

Tests are the same plain-script style as before, `python3 test_fd_validate.py` → 23 pass. Against the old validator wired to the same import, **12 of the 15 new cases fail** (the other 3 pin behaviour this PR deliberately keeps). The last test walks every shipped scene and compares against the ground-truth list above, so a template that stops parsing gets noticed.

## Flagged, not fixed

- `scenes/templates/{asteroid_field,bouncy_90s_demo,chrome_text_logo,glass_city_skyline}.pov` are broken today — they are now correctly reported, but I did not edit the scenes; the fix (rename `x`/`y` params, move `no_shadow` out of `texture{}`, unwrap `Retro_*`) is a content call, not a validator call.
- `sanitize()` in `ai_scene.py` cuts leading prose at the first `#include|#version|camera|sphere|sky_sphere|Retro_`, which also matches those words inside prose, and its closing-fence strip only anchors at end-of-text — trailing prose after a ``` fence reaches the .pov. Untouched here.
- `_fix_color` rescales all three components when any exceeds 1.5, so a deliberate over-bright `rgb <2.0,0.5,0.5>` becomes near-black. Untouched.
